### PR TITLE
Upgrade dependencies to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: push
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   check:

--- a/build-logic/plugins/build.gradle.dcl
+++ b/build-logic/plugins/build.gradle.dcl
@@ -3,12 +3,12 @@ javaGradlePlugin {
 
     dependencies {
         api("org.gradle.experimental.kmp-ecosystem:org.gradle.experimental.kmp-ecosystem.gradle.plugin:0.1.46")
-        api("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:2.2.0")
-        api("org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:2.2.0")
-        api("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.2.0")
-        api("org.jetbrains.compose:compose-gradle-plugin:1.6.11")
-        api("app.cash.sqldelight:gradle-plugin:2.0.2")
-        api("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
+        api("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:2.2.20")
+        api("org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:2.2.20")
+        api("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.2.20")
+        api("org.jetbrains.compose:compose-gradle-plugin:1.9.0")
+        api("app.cash.sqldelight:gradle-plugin:2.1.0")
+        api("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8")
     }
 
     registers {

--- a/gradle-client/build.gradle.dcl
+++ b/gradle-client/build.gradle.dcl
@@ -121,12 +121,15 @@ kotlinApplication {
             appResourcesRootDir = layout.projectDirectory.dir("src/assets")
 
             modules = listOf(
+                "java.datatransfer",
+                "java.desktop",
                 "java.instrument",
                 "java.management",
                 "java.naming",
                 "java.scripting",
                 "java.sql",
                 "jdk.compiler",
+                "jdk.crypto.ec",
                 "jdk.security.auth",
                 "jdk.unsupported",
             )

--- a/gradle-client/build.gradle.dcl
+++ b/gradle-client/build.gradle.dcl
@@ -6,9 +6,9 @@ kotlinApplication {
     version = "1.1.3"
 
     dependencies {
-        implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.21"))
-        implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1"))
-        implementation(platform("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3"))
+        implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.2.20"))
+        implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2"))
+        implementation(platform("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.9.0"))
     }
 
     targets {
@@ -21,45 +21,45 @@ kotlinApplication {
 
                 implementation("org.gradle:gradle-tooling-api:9.2.0-milestone-2")
 
-                implementation("com.arkivanov.decompose:decompose:3.0.0")
-                implementation("com.arkivanov.decompose:extensions-compose:3.0.0")
-                implementation("com.arkivanov.essenty:lifecycle-coroutines:1.3.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+                implementation("com.arkivanov.decompose:decompose:3.3.0")
+                implementation("com.arkivanov.decompose:extensions-compose:3.3.0")
+                implementation("com.arkivanov.essenty:lifecycle-coroutines:2.5.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+                implementation("io.ktor:ktor-client-okhttp:3.3.0")
+                implementation("io.ktor:ktor-serialization-kotlinx-json:3.3.0")
 
                 implementation("dev.chrisbanes.material3:material3-window-size-class-multiplatform:0.5.0")
-                implementation("com.materialkolor:material-kolor:1.7.0")
-                implementation("io.github.vinceglb:filekit-compose:0.8.2")
+                implementation("com.materialkolor:material-kolor:3.0.1")
+                implementation("io.github.vinceglb:filekit-dialogs-compose:0.11.0")
 
-                implementation("org.slf4j:slf4j-api:2.0.14")
-                implementation("ch.qos.logback:logback-classic:1.5.6")
+                implementation("org.slf4j:slf4j-api:2.0.17")
+                implementation("ch.qos.logback:logback-classic:1.5.18")
 
                 implementation("org.gradle:gradle-declarative-dsl-core:9.2.0-milestone-2")
                 implementation("org.gradle:gradle-declarative-dsl-evaluator:9.2.0-milestone-2")
                 implementation("org.gradle:gradle-declarative-dsl-tooling-models:9.2.0-milestone-2")
                 implementation("org.jspecify:jspecify:1.0.0")
 
-                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.8.1")
+                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2")
 
-                implementation("org.jetbrains.compose.runtime:runtime:1.6.11")
-                implementation("org.jetbrains.compose.foundation:foundation:1.6.11")
-                implementation("org.jetbrains.compose.material3:material3:1.6.11")
-                implementation("org.jetbrains.compose.material:material-icons-extended:1.6.11")
-                implementation("org.jetbrains.compose.ui:ui:1.6.11")
-                implementation("org.jetbrains.compose.components:components-resources:1.6.11")
-                implementation("org.jetbrains.compose.components:components-ui-tooling-preview:1.6.11")
-                implementation("org.jetbrains.compose.desktop:desktop-jvm-macos-arm64:1.6.11")
-                implementation("org.jetbrains.compose.desktop:desktop-jvm-linux-x64:1.6.11")
-                implementation("org.jetbrains.compose.desktop:desktop-jvm-windows-x64:1.6.11")
+                implementation("org.jetbrains.compose.runtime:runtime:1.9.0")
+                implementation("org.jetbrains.compose.foundation:foundation:1.9.0")
+                implementation("org.jetbrains.compose.material3:material3:1.10.0-alpha01")
+                implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
+                implementation("org.jetbrains.compose.ui:ui:1.9.0")
+                implementation("org.jetbrains.compose.components:components-resources:1.9.0")
+                implementation("org.jetbrains.compose.components:components-ui-tooling-preview:1.9.0")
+                implementation("org.jetbrains.compose.desktop:desktop-jvm-macos-arm64:1.9.0")
+                implementation("org.jetbrains.compose.desktop:desktop-jvm-linux-x64:1.9.0")
+                implementation("org.jetbrains.compose.desktop:desktop-jvm-windows-x64:1.9.0")
             }
 
             testing {
                 dependencies {
-                    implementation("org.jetbrains.compose.ui:ui-test-junit4:1.6.11")
+                    implementation("org.jetbrains.compose.ui:ui-test-junit4:1.9.0")
 
-                    runtimeOnly("org.junit.vintage:junit-vintage-engine:5.12.0")
+                    runtimeOnly("org.junit.vintage:junit-vintage-engine:5.13.4")
                     runtimeOnly("org.junit.platform:junit-platform-launcher:1.13.4")
                 }
             }

--- a/gradle-client/proguard-desktop.pro
+++ b/gradle-client/proguard-desktop.pro
@@ -11,13 +11,16 @@
 # =========================================================================
 # UNUSED CLASSES
 
-# Logback dynamic janino
+# Logback unused dependencies
 -dontwarn org.codehaus.janino.**
 -dontwarn org.codehaus.commons.compiler.**
-
-# Logback networking
 -dontwarn jakarta.servlet.**
 -dontwarn jakarta.mail.**
+-dontwarn org.tukaani.xz.**
+
+# Kotlin
+-dontwarn kotlin.jvm.internal.EnhancedNullability
+-dontwarn kotlin.concurrent.atomics.**
 
 # Kotlinx DateTime
 -dontwarn kotlinx.datetime.**
@@ -25,23 +28,17 @@
 # Android
 -dontwarn android.**
 
-# OkHttp3 Crypto
+# OkHttp3 unused dependencies
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+-dontwarn org.graalvm.nativeimage.**
+-dontwarn com.oracle.svm.**
 
 # Kotlin embedded compiler dependencies
 -dontwarn kotlin.annotations.jvm.**
 -dontwarn org.jetbrains.concurrency.**
--dontwarn org.jetbrains.kotlin.com.google.common.**
--dontwarn org.jetbrains.kotlin.com.google.gson.**
--dontwarn org.jetbrains.kotlin.com.google.errorprone.**
--dontwarn org.jetbrains.kotlin.com.google.j2objc.**
--dontwarn org.jetbrains.kotlin.org.jline.**
--dontwarn org.jetbrains.kotlin.cli.jvm.javac.**
--dontwarn org.jetbrains.kotlin.com.intellij.**
--dontwarn org.jetbrains.kotlin.javac.**
--dontwarn org.jetbrains.kotlin.io.**
+-dontwarn org.jetbrains.kotlin.**
 -dontwarn org.checkerframework.**
 
 # =========================================================================

--- a/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/build/BuildContent.kt
+++ b/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/build/BuildContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
-import io.github.vinceglb.filekit.compose.rememberDirectoryPickerLauncher
+import io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher
 import kotlinx.coroutines.launch
 import org.gradle.client.core.database.Build
 import org.gradle.client.core.gradle.GradleConnectionParameters

--- a/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/buildlist/BuildListContent.kt
+++ b/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/buildlist/BuildListContent.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
-import io.github.vinceglb.filekit.compose.rememberDirectoryPickerLauncher
+import io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.gradle.client.core.Constants.APPLICATION_DISPLAY_NAME

--- a/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/composables/Texts.kt
+++ b/gradle-client/src/jvmMain/kotlin/org/gradle/client/ui/composables/Texts.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.ClickableText
-import androidx.compose.foundation.text2.input.maxLengthInChars
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/mutations-demo/src/main/kotlin/AgpMutationDefinitions.kt
+++ b/mutations-demo/src/main/kotlin/AgpMutationDefinitions.kt
@@ -54,7 +54,7 @@ val enableCompose = run {
         AnalysisSchema::hasAgp,
         { ScopeLocation.fromTopLevel().inObjectsOfType(agpAndroidLibrary) },
         { agpAndroidLibrary.singleFunctionNamed("dependenciesDcl") },
-        { _ -> elementFromString("implementation(\"androidx.compose.material3:material3:1.3.0\")") }
+        { _ -> elementFromString("implementation(\"androidx.compose.material3:material3:1.3.2\")") }
     )
 
     object : AgpMutationDefinition {


### PR DESCRIPTION
This was done manually as DCL unfortunately does not support version catalogs yet [1], for which several tools exist to perform upgrades automatically.

[1]: https://declarative.gradle.org/docs/reference/migration-guide/#hints-tips-and-footguns